### PR TITLE
fix: auto-generate username for users missing a valid one

### DIFF
--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { onAuthStateChanged } from "firebase/auth";
-import { doc, getDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
 import { auth, db } from "../../firebase/config";
 import { useLang } from "../../context/LangContext";
 import { getLevel, getGreetingKey, getInitials } from "../../utils/profileHelpers";
+import { generateUniqueUsername, formatUsername } from "../../utils/generateUsername";
 import SettingsMenu from "../../components/SettingsMenu/SettingsMenu";
 import "./ProfilePage.css";
 
@@ -40,8 +41,22 @@ const ProfilePage = () => {
       }
 
       try {
-        const userDoc = await getDoc(doc(db, "users", user.uid));
-        if (userDoc.exists()) setUserData(userDoc.data() as UserData);
+        const userDocRef = doc(db, "users", user.uid);
+        const userDoc = await getDoc(userDocRef);
+        let data: UserData | null = userDoc.exists() ? (userDoc.data() as UserData) : null;
+
+        if (!data?.fullUsername?.includes("#")) {
+          const { name, tag } = await generateUniqueUsername(user.uid);
+          const full = formatUsername(name, tag);
+          await setDoc(
+            userDocRef,
+            { username: name, tag, fullUsername: full, email: data?.email ?? user.email ?? "" },
+            { merge: true },
+          );
+          data = { ...(data ?? { email: user.email ?? "" }), fullUsername: full };
+        }
+
+        setUserData(data);
 
         const resultDoc = await getDoc(doc(db, "quizResults", user.uid));
         if (resultDoc.exists()) setTestResult(resultDoc.data() as TestResult);


### PR DESCRIPTION
This pull request updates the `ProfilePage` to ensure that each user has a unique, properly formatted username (including a tag, e.g., `username#1234`). If a user's `fullUsername` is missing or not in the expected format, the system now generates and saves one automatically. Additionally, new utility functions are imported to support this functionality.

The most important changes are:

**Username generation and assignment:**

* When loading a user's profile, the code now checks if the `fullUsername` field exists and contains a tag (with `#`). If not, it generates a unique username and tag using `generateUniqueUsername`, formats it with `formatUsername`, and updates the user's Firestore document accordingly.

**Imports and utilities:**

* Added imports for `setDoc` from `firebase/firestore` and for the new utility functions `generateUniqueUsername` and `formatUsername` to support the username generation and formatting logic.