### PR TITLE
fix: move theme and language buttons to top-right corner on login/reg…

### DIFF
--- a/src/components/LangToggle/LangToggle.css
+++ b/src/components/LangToggle/LangToggle.css
@@ -3,8 +3,8 @@
 .lang-toggle {
   position: fixed;
   top: 1rem;
-  /* 1rem gap + 44px menu button + 0.5rem + 44px theme button + 0.5rem */
-  right: calc(1rem + 44px + 0.5rem + 44px + 0.5rem);
+  /* immediately left of the ThemeToggle button */
+  right: calc(1rem + 44px + 0.5rem);
   z-index: 200;
 
   display: flex;

--- a/src/components/ThemeToggle/ThemeToggle.css
+++ b/src/components/ThemeToggle/ThemeToggle.css
@@ -3,8 +3,7 @@
 .theme-toggle {
   position: fixed;
   top: 1rem;
-  /* 1rem gap + 44px menu button + 0.5rem spacing */
-  right: calc(1rem + 44px + 0.5rem);
+  right: 1rem;
   z-index: 200;
 
   display: flex;


### PR DESCRIPTION
This pull request updates the positioning of the `LangToggle` and `ThemeToggle` components to improve their layout in the UI. The changes simplify the calculation for the right offset, ensuring both toggles are placed correctly relative to each other.

Layout and positioning adjustments:

* Updated the `right` offset in `ThemeToggle.css` so the theme toggle button is now positioned at `1rem` from the right edge, simplifying its placement.
* Adjusted the `right` offset in `LangToggle.css` so it sits immediately to the left of the theme toggle button, ensuring consistent spacing and alignment between the toggles.…istration pages