### PR TITLE
feat: add password reset page with email-based reset flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ProfilePage from "./pages/ProfilePage/ProfilePage";
 import SettingsPage from "./pages/SettingsPage/SettingsPage";
 import EmailChangePage from "./pages/EmailChangePage/EmailChangePage";
 import PasswordChangePage from "./pages/PasswordChangePage/PasswordChangePage";
+import PasswordResetPage from "./pages/PasswordResetPage/PasswordResetPage";
 import VerifyEmailPage from "./pages/VerifyEmailPage/VerifyEmailPage";
 import SurveyPage from "./pages/SurveyPage/SurveyPage";
 import "./App.css";
@@ -17,6 +18,7 @@ function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/reset-password" element={<PasswordResetPage />} />
             <Route path="/verify-email" element={<VerifyEmailPage />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/survey" element={<SurveyPage />} />

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -281,6 +281,18 @@ const LoginPage = () => {
           </button>
         </form>
 
+        {!isSignUp && (
+          <p className="login-toggle">
+            <button
+              type="button"
+              className="login-toggle-btn"
+              onClick={() => navigate("/reset-password")}
+            >
+              {t.forgotPassword}
+            </button>
+          </p>
+        )}
+
         <p className="login-toggle">
           {isSignUp ? t.alreadyHaveAccount : t.dontHaveAccount}{" "}
           <button

--- a/src/pages/PasswordResetPage/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage/PasswordResetPage.tsx
@@ -1,0 +1,119 @@
+import { useState, type FormEvent } from "react";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { useNavigate } from "react-router-dom";
+import { auth } from "../../firebase/config";
+import { useLang } from "../../context/LangContext";
+import ThemeToggle from "../../components/ThemeToggle/ThemeToggle";
+import LangToggle from "../../components/LangToggle/LangToggle";
+import "../LoginPage/LoginPage.css";
+
+const PasswordResetPage = () => {
+  const { t } = useLang();
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      await sendPasswordResetEmail(auth, email);
+      setSent(true);
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code ?? "";
+      if (code === "auth/invalid-email") setError(t.errorInvalidEmail);
+      else if (code === "auth/too-many-requests") setError(t.errorTooManyRequests);
+      else if (code === "auth/network-request-failed") setError(t.errorNetworkFailed);
+      else setError(t.unexpectedError);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <div className="login-page">
+        <ThemeToggle />
+        <LangToggle />
+        <div className="login-bg-shape login-bg-shape--1" />
+        <div className="login-bg-shape login-bg-shape--2" />
+        <div className="login-bg-shape login-bg-shape--3" />
+
+        <div className="login-card username-reveal">
+          <div className="login-header">
+            <h1 className="login-title">{t.resetSent}</h1>
+            <p className="login-subtitle">{t.resetEmailSentDesc}</p>
+          </div>
+          <button
+            className="login-button"
+            onClick={() => navigate("/login")}
+          >
+            {t.backToLogin}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="login-page">
+      <ThemeToggle />
+      <LangToggle />
+      <div className="login-bg-shape login-bg-shape--1" />
+      <div className="login-bg-shape login-bg-shape--2" />
+      <div className="login-bg-shape login-bg-shape--3" />
+
+      <div className="login-card">
+        <div className="login-header">
+          <h1 className="login-title">{t.resetPasswordTitle}</h1>
+          <p className="login-subtitle">{t.resetPasswordSubtitle}</p>
+        </div>
+
+        <form className="login-form" onSubmit={handleSubmit}>
+          <div className="login-field">
+            <label htmlFor="email" className="login-label">
+              {t.email}
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="login-input"
+              placeholder={t.emailPlaceholder}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+            />
+          </div>
+
+          {error && <p className="login-error">{error}</p>}
+
+          <button
+            type="submit"
+            className="login-button"
+            disabled={loading}
+          >
+            {loading ? t.loading : t.sendResetEmail}
+          </button>
+        </form>
+
+        <p className="login-toggle">
+          <button
+            type="button"
+            className="login-toggle-btn"
+            onClick={() => navigate("/login")}
+          >
+            {t.backToLogin}
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordResetPage;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -146,6 +146,13 @@ export const translations = {
     errorRequiresRecentLogin: "Please sign in again to continue.",
     errorUserDisabled: "This account has been disabled. Contact support.",
     surveySaveError: "Your results could not be saved. Please check your connection.",
+    // Password reset page
+    forgotPassword: "Forgot password?",
+    resetPasswordTitle: "Reset Password",
+    resetPasswordSubtitle: "Enter your email and we'll send you a reset link.",
+    sendResetEmail: "Send Reset Email",
+    resetEmailSentDesc: "Check your inbox for a password reset link. You can close this page.",
+    backToLogin: "Back to Login",
   },
   lv: {
     // Login page
@@ -289,6 +296,13 @@ export const translations = {
     errorRequiresRecentLogin: "Lūdzu, piesakieties vēlreiz, lai turpinātu.",
     errorUserDisabled: "Šis konts ir atspējots. Sazinieties ar atbalstu.",
     surveySaveError: "Rezultāti netika saglabāti. Pārbaudiet savienojumu.",
+    // Password reset page
+    forgotPassword: "Aizmirs\u0101t paroli?",
+    resetPasswordTitle: "Atiestat\u012Bt paroli",
+    resetPasswordSubtitle: "Ievadiet savu e-pastu un m\u0113s nos\u016Bt\u012Bsim atiestat\u012B\u0161anas saiti.",
+    sendResetEmail: "Nos\u016Bt\u012Bt atiestat\u012B\u0161anas e-pastu",
+    resetEmailSentDesc: "P\u0101rbaudiet savu pastkasti. Paroles atiestat\u012B\u0161anas saite ir nos\u016Bt\u012Bta.",
+    backToLogin: "Atpaka\u013C uz pieteik\u0161anos",
   },
 } as const;
 


### PR DESCRIPTION
This pull request adds a password reset feature to the application, allowing users to request a password reset email if they've forgotten their password. It introduces a new page for password resets, updates the login page to link to this new feature, and provides translations for the new UI elements in both English and Latvian.

**Password reset feature:**

* Added a new `PasswordResetPage` component that allows users to enter their email and request a password reset link. The page includes error handling, loading state, and confirmation messaging. (`src/pages/PasswordResetPage/PasswordResetPage.tsx`)
* Added a route for `/reset-password` in the main app router to display the new password reset page. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R9) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R21)
* Updated the login page to include a "Forgot password?" button that navigates to the password reset page. (`src/pages/LoginPage/LoginPage.tsx`)

**Localization:**

* Added English and Latvian translations for all password reset related UI text, including error messages and button labels. (`src/translations/index.ts`) [[1]](diffhunk://#diff-cc401d7e0105fb8984cad9ad186d5d843df49f2cea93e8e4d75bda3d3d9daeeaR149-R155) [[2]](diffhunk://#diff-cc401d7e0105fb8984cad9ad186d5d843df49f2cea93e8e4d75bda3d3d9daeeaR299-R305)