### PR TITLE
Make STLAT logo clickable for users and admins

### DIFF
--- a/src/components/AdminLayout/AdminLayout.css
+++ b/src/components/AdminLayout/AdminLayout.css
@@ -23,6 +23,11 @@
   border-bottom: 1px solid var(--border);
 }
 
+.admin-logo-link {
+  text-decoration: none;
+  color: inherit;
+}
+
 .admin-sidebar-title {
   font-size: 1.25rem;
   font-weight: 700;

--- a/src/components/AdminLayout/AdminLayout.tsx
+++ b/src/components/AdminLayout/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { Link, NavLink, Outlet, useNavigate } from "react-router-dom";
 import { doc, getDoc } from "firebase/firestore";
 import { signOut } from "firebase/auth";
 import { auth, db } from "../../firebase/config";
@@ -52,7 +52,9 @@ const AdminLayout = () => {
       {/* Sidebar */}
       <aside className={`admin-sidebar${sidebarOpen ? " open" : ""}`}>
         <div className="admin-sidebar-header">
-          <h2 className="admin-sidebar-title">STLAT</h2>
+          <Link to="/admin" className="admin-logo-link">
+            <h2 className="admin-sidebar-title">STLAT</h2>
+          </Link>
           <p className="admin-sidebar-subtitle">{t.adminPanel}</p>
         </div>
 

--- a/src/pages/ProfilePage/ProfilePage.css
+++ b/src/pages/ProfilePage/ProfilePage.css
@@ -85,6 +85,11 @@
   align-self: start;
 }
 
+.sidebar-logo-link {
+  text-decoration: none;
+  color: inherit;
+}
+
 .sidebar-logo {
   display: block;
   font-size: 1.25rem;

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { doc, getDoc, setDoc } from "firebase/firestore";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { db } from "../../firebase/config";
 import { USERS, QUIZ_RESULTS } from "../../firebase/collections";
 import { useLang } from "../../context/LangContext";
@@ -105,7 +105,9 @@ const ProfilePage = () => {
         {/* ── Left sidebar ── */}
         <aside className="profile-sidebar">
           <nav className="sidebar-nav">
-            <span className="sidebar-logo">STLAT</span>
+            <Link to="/profile" className="sidebar-logo-link">
+              <span className="sidebar-logo">STLAT</span>
+            </Link>
             <div className="sidebar-divider" />
             <button className="sidebar-btn sidebar-btn--active">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></svg>


### PR DESCRIPTION
This pull request improves the navigation experience and accessibility of the admin and profile sidebars by wrapping the site logo in a link to the respective dashboard pages. It also introduces new CSS classes to ensure the logo links are styled consistently with the rest of the sidebar.

Navigation and accessibility improvements:

* The `STLAT` logo in the admin sidebar is now wrapped in a `Link` to `/admin`, making it clickable and improving navigation. (`src/components/AdminLayout/AdminLayout.tsx`, [src/components/AdminLayout/AdminLayout.tsxR55-R57](diffhunk://#diff-d37d76f9d4ab1b4edeedad771d5711c7213b85af0e3807508bc59199bd65c0e6R55-R57))
* The `STLAT` logo in the profile sidebar is now wrapped in a `Link` to `/profile`, providing a consistent and intuitive way to return to the profile dashboard. (`src/pages/ProfilePage/ProfilePage.tsx`, [src/pages/ProfilePage/ProfilePage.tsxR108-R110](diffhunk://#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0R108-R110))

Styling consistency:

* Added `.admin-logo-link` and `.sidebar-logo-link` CSS classes to style the logo links so they inherit text color and remove default link underlines, maintaining the sidebar's visual design. (`src/components/AdminLayout/AdminLayout.css`, [[1]](diffhunk://#diff-6ba13e3da514f840ba871690d37e43763d80b33e0a03554af409025f4963c117R26-R30); `src/pages/ProfilePage/ProfilePage.css`, [[2]](diffhunk://#diff-d08b7291adf710b046e6888e4bc3de01598279e0de139d1c913c2ad2a1cc5532R88-R92)

Codebase updates for routing:

* Updated imports to include `Link` from `react-router-dom` in both `AdminLayout.tsx` and `ProfilePage.tsx` to support the new logo links. (`src/components/AdminLayout/AdminLayout.tsx`, [[1]](diffhunk://#diff-d37d76f9d4ab1b4edeedad771d5711c7213b85af0e3807508bc59199bd65c0e6L2-R2); `src/pages/ProfilePage/ProfilePage.tsx`, [[2]](diffhunk://#diff-bb52971d8c2a4e27cacc22c03efd7d49b214af77d7451e9e67e1cc3b485ad6f0L3-R3)…/admin